### PR TITLE
Add extra target for running the tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,6 @@ Dependencies
 `catsim` depends on the latest versions of NumPy, SciPy, Matplotlib and scikit-learn,
 which are automatically installed from `pip`.
 
-To run the tests, you'll need `nose`.
+To run the tests, you'll need to install the testing requirements `pip install catsim[testing]`.
 
 To generate the documentation, Sphinx and its dependencies are needed.

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,8 @@ setup(
     install_requires=[
         'numpy', 'scipy', 'matplotlib', 'scikit-learn', 'json_tricks'
     ],
+    extras_require = dict(
+        testing=['nose', 'nose-cov'],
+    ),
     license='GPLv2'
 )


### PR DESCRIPTION
nose was mentioned in the documentation, but nose-cov is an implicit
requirement by the Makefile. This addition allows installing testing
requirements using either
`pip install catsim[testing]` or `pip install -e .[testing]` when
developing.