### PR TITLE
Updated index which causes out of bounds error

### DIFF
--- a/catsim/selection.py
+++ b/catsim/selection.py
@@ -80,7 +80,7 @@ class MaxInfoSelector(Selector):
             return None
 
         # gets the indexes and information values from the items with r < rmax
-        valid_indexes_low_r = [index for index in valid_indexes if items[index, 4] < self._r_max]
+        valid_indexes_low_r = [index for index in valid_indexes if items[index, 3] < self._r_max]
 
         # return the item with maximum information from the ones available
         if len(valid_indexes_low_r) > 0:


### PR DESCRIPTION
Hey Douglas,

I went back and checked on this today and noticed this piece of the code was throwing an error in Issue #14 

`[index for index in valid_indexes if items[index, 4] < self._r_max]`

The code is referencing index 4 in a 4 column item_bank ndarray. When I changed the above to the below, it works as intended.

`[index for index in valid_indexes if items[index, 3] < self._r_max]`

Note, I just looked at the MaxInfoSelector class alone, I'm assuming this '4' index is used elsewhere in the file as well.