### PR TITLE
Fix normalize_item_bank(...)

### DIFF
--- a/catsim/irt.py
+++ b/catsim/irt.py
@@ -330,11 +330,11 @@ def normalize_item_bank(items: numpy.ndarray) -> numpy.ndarray:
     if len(items.shape) == 1:
         items = numpy.expand_dims(items, axis=0)
     if items.shape[1] == 1:
-        items = numpy.append(numpy.ones((items.shape[0])), items, axis=1)
+        items = numpy.append(numpy.ones((items.shape[0], 1)), items, axis=1)
     if items.shape[1] == 2:
-        items = numpy.append(items, numpy.zeros((items.shape[0])), axis=1)
+        items = numpy.append(items, numpy.zeros((items.shape[0], 1)), axis=1)
     if items.shape[1] == 3:
-        items = numpy.append(items, numpy.ones((items.shape[0])), axis=1)
+        items = numpy.append(items, numpy.ones((items.shape[0], 1)), axis=1)
 
     return items
 


### PR DESCRIPTION
Currently calling normalize_item_bank(...) on an array like so:

```
[[-2.0044746   1.1755979 ]
 [-1.7894522   1.047313  ]
 [-0.94069207  1.0814952 ]
 ...
 [-1.4703591   0.8663169 ]
 [ 0.59085643  0.7291509 ]
 [-1.177184    1.002756  ]]
```

Gives:

```
    bank = normalize_item_bank(bank)
  File "path/to/catsim/irt.py", line 336, in normalize_item_bank
    items = numpy.append(items, numpy.zeros((items.shape[0])), axis=1)
  File "<__array_function__ internals>", line 5, in append
  File "path/to/numpy/lib/function_base.py", line 4745, in append
    return concatenate((arr, values), axis=axis)
  File "<__array_function__ internals>", line 5, in concatenate
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 2 dimension(s) and the array at index 1 has 1 dimension(s)
```

This PR fixes up the shapes of the extra columns.