### PR TITLE
Modernize linting, type checks, and CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,9 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
       github.event_name == 'release'
     runs-on: ${{ matrix.os }}
+    env:
+      # Force a headless backend so plot tests don't depend on Tk/Tcl being available on runners.
+      MPLBACKEND: Agg
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,11 +25,20 @@ jobs:
     name: Pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: pre-commit/action@v3.0.1
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: uv run --only-group dev pre-commit run --all-files
 
   test:
     name: Run tests
@@ -53,16 +62,16 @@ jobs:
             python-version: "3.13"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -90,13 +99,13 @@ jobs:
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -184,15 +193,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -249,7 +258,7 @@ jobs:
           path: docs/build/html/
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: gh-pages-checkout
@@ -295,7 +304,7 @@ jobs:
           path: docs/build/html/
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: gh-pages-checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 
   # 4. Linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.6
+    rev: v0.15.9
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,15 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: local
+    hooks:
+      - id: ty-check
+        name: ty check
+        entry: uv run --only-group dev ty check
+        language: system
+        pass_filenames: false
+        types_or: [python, pyi]
+
   # 5. Other formatters
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ select = [
     "ANN",
     "B",
     "A",
+    "BLE",
     "C4",
     "EM",
     "EXE",
@@ -88,9 +89,10 @@ select = [
     "NPY",
     "PERF",
     "FURB",
+    "S",
     "RUF",
 ]
-ignore = ["ANN401", "D100", "E111", "E114"]
+ignore = ["ANN401", "D100", "E111", "E114", "S101"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -106,6 +108,7 @@ convention = "numpy"
 "tests/*" = [
   "PLR6301",  # Test methods don't need to use self
   "PLR2004",  # Magic values are fine in tests - they're explicit test expectations
+  "S",        # Security rules are too noisy for intentionally non-production test code
 ]
 
 [tool.ruff.format]
@@ -124,8 +127,9 @@ line-ending = "auto"
 [dependency-groups]
 dev = [
     "ipykernel>=7.1.0",
-    "pre-commit>=4.3.0",
-    "ruff>=0.13.3",
+    "pre-commit>=4.5.1",
+    "ruff>=0.15.9",
+    "ty>=0.0.28",
 ]
 docs = [
     "bibtex-pygments-lexer>=0.0.1",
@@ -140,6 +144,17 @@ testing = [
     "pytest>=8.4.2",
     "pytest-cov>=7.0.0",
     "pytest-xdist>=3.6.1",
-    "ruff>=0.13.3",
+    "ruff>=0.15.9",
     "scikit-learn>=1.7.2",
 ]
+
+[tool.ty.src]
+include = ["src/catsim"]
+
+[tool.ty.rules]
+all = "ignore"
+division-by-zero = "error"
+possibly-missing-import = "error"
+redundant-cast = "error"
+unused-ignore-comment = "error"
+unused-type-ignore-comment = "error"

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -23,9 +23,7 @@ sys.path.insert(0, pathlib.Path("..").resolve())
 
 filenames = ["readme_head.md", "readme_body.md"]
 with pathlib.Path("../README.md").open("w", encoding="utf-8") as outfile:
-  for fname in filenames:
-    with pathlib.Path(fname).open(encoding="utf-8") as infile:
-      outfile.write(infile.read())
+  outfile.writelines(pathlib.Path(fname).read_text(encoding="utf-8") for fname in filenames)
 
 # -- General configuration ------------------------------------------------
 

--- a/src/catsim/estimation/base.py
+++ b/src/catsim/estimation/base.py
@@ -100,4 +100,6 @@ class BaseEstimator(Simulable, ABC):
     float
         Average number of function evaluations per test.
     """
+    if self._calls == 0:
+      return 0.0
     return self._evaluations / self._calls

--- a/src/catsim/irt.py
+++ b/src/catsim/irt.py
@@ -469,6 +469,12 @@ def theta_to_scale(
   float or numpy.ndarray
       The transformed score(s) on the target scale. Returns the same type as input.
 
+  Notes
+  -----
+  - Values outside [theta_min, theta_max] are extrapolated linearly
+  - The transformation preserves relative distances between ability levels
+  - Common score scales: 0-100, 200-800 (SAT), 0-500 (TOEFL), etc.
+
   Examples
   --------
   >>> # Convert theta to 0-100 scale
@@ -488,12 +494,6 @@ def theta_to_scale(
   >>> thetas = np.array([-4, -2, 0, 2, 4])
   >>> theta_to_scale(thetas)  # doctest: +SKIP
   array([  0.,  25.,  50.,  75., 100.])
-
-  Notes
-  -----
-  - Values outside [theta_min, theta_max] are extrapolated linearly
-  - The transformation preserves relative distances between ability levels
-  - Common score scales: 0-100, 200-800 (SAT), 0-500 (TOEFL), etc.
   """
   if theta_max <= theta_min:
     msg = f"theta_max ({theta_max}) must be greater than theta_min ({theta_min})"
@@ -546,6 +546,12 @@ def scale_to_theta(
   float or numpy.ndarray
       The transformed theta value(s). Returns the same type as input.
 
+  Notes
+  -----
+  - This is the inverse of :py:func:`theta_to_scale`
+  - Useful for converting cutoff scores to theta values for classification
+  - Preserves the relative ordering and distances of scores
+
   Examples
   --------
   >>> # Convert 0-100 score to theta
@@ -565,12 +571,6 @@ def scale_to_theta(
   >>> scores = np.array([0, 25, 50, 75, 100])
   >>> scale_to_theta(scores)  # doctest: +SKIP
   array([-4., -2.,  0.,  2.,  4.])
-
-  Notes
-  -----
-  - This is the inverse of :py:func:`theta_to_scale`
-  - Useful for converting cutoff scores to theta values for classification
-  - Preserves the relative ordering and distances of scores
   """
   if theta_max <= theta_min:
     msg = f"theta_max ({theta_max}) must be greater than theta_min ({theta_min})"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -21,10 +21,9 @@ class TestNoItemsAvailableError:
   def test_message_is_preserved(self) -> None:
     """Test that the error message is preserved."""
     message = "Custom error message"
-    try:
+    with pytest.raises(NoItemsAvailableError) as exc_info:
       raise NoItemsAvailableError(message)
-    except NoItemsAvailableError as e:
-      assert str(e) == message
+    assert str(exc_info.value) == message
 
   def test_can_be_caught_as_runtime_error(self) -> None:
     """Test that it can be caught as RuntimeError."""

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -170,7 +170,7 @@ class TestFixedPointInitializerInitialize:
 
     for _ in range(10):
       theta = initializer.initialize()
-      assert theta == start
+      assert theta == pytest.approx(start)
 
   def test_initialize_ignores_index(self) -> None:
     """Test that initialize ignores the index parameter."""
@@ -178,17 +178,17 @@ class TestFixedPointInitializerInitialize:
 
     for i in range(10):
       theta = initializer.initialize(index=i)
-      assert theta == 0.0
+      assert theta == pytest.approx(0.0)
 
   def test_initialize_zero(self) -> None:
     """Test initialization with zero."""
     initializer = FixedPointInitializer(0.0)
-    assert initializer.initialize() == 0.0
+    assert initializer.initialize() == pytest.approx(0.0)
 
   def test_initialize_negative(self) -> None:
     """Test initialization with negative value."""
     initializer = FixedPointInitializer(-3.0)
-    assert initializer.initialize() == -3.0
+    assert initializer.initialize() == pytest.approx(-3.0)
 
 
 class TestBaseInitializerAbstract:
@@ -216,4 +216,4 @@ class TestBaseInitializerAbstract:
         return 42.0
 
     initializer = ConstantInitializer()
-    assert initializer.initialize() == 42.0
+    assert initializer.initialize() == pytest.approx(42.0)

--- a/tests/test_irt.py
+++ b/tests/test_irt.py
@@ -281,24 +281,24 @@ class TestNormalizeItemBank:
     normalized = irt.normalize_item_bank(items)
     assert normalized.shape == (2, 4)
     # Check a=1, b=original, c=0, d=1
-    assert np.all(normalized[:, 0] == 1.0)  # a
-    assert np.all(normalized[:, 2] == 0.0)  # c
-    assert np.all(normalized[:, 3] == 1.0)  # d
+    assert np.allclose(normalized[:, 0], 1.0)  # a
+    assert np.allclose(normalized[:, 2], 0.0)  # c
+    assert np.allclose(normalized[:, 3], 1.0)  # d
 
   def test_normalize_2pl(self) -> None:
     """Test normalization of 2PL (a, b)."""
     items = np.array([[1.5, 0.0], [1.0, 1.0]])
     normalized = irt.normalize_item_bank(items)
     assert normalized.shape == (2, 4)
-    assert np.all(normalized[:, 2] == 0.0)  # c
-    assert np.all(normalized[:, 3] == 1.0)  # d
+    assert np.allclose(normalized[:, 2], 0.0)  # c
+    assert np.allclose(normalized[:, 3], 1.0)  # d
 
   def test_normalize_3pl(self) -> None:
     """Test normalization of 3PL (a, b, c)."""
     items = np.array([[1.5, 0.0, 0.2], [1.0, 1.0, 0.1]])
     normalized = irt.normalize_item_bank(items)
     assert normalized.shape == (2, 4)
-    assert np.all(normalized[:, 3] == 1.0)  # d
+    assert np.allclose(normalized[:, 3], 1.0)  # d
 
   def test_normalize_4pl_unchanged(self) -> None:
     """Test that 4PL items are returned unchanged."""

--- a/tests/test_item_bank.py
+++ b/tests/test_item_bank.py
@@ -33,7 +33,7 @@ class TestItemBankCreation:
     assert bank.n_items == 2
     assert bank.items.shape == (2, 5)
     # d should be added as 1.0
-    assert np.all(bank.upper_asymptote == 1.0)
+    assert np.allclose(bank.upper_asymptote, 1.0)
 
   def test_create_from_2pl_params(self) -> None:
     """Test creating ItemBank from 2PL parameters."""
@@ -46,8 +46,8 @@ class TestItemBankCreation:
     assert bank.n_items == 2
     assert bank.model == 2  # 2PL
     # c should be 0, d should be 1
-    assert np.all(bank.pseudo_guessing == 0.0)
-    assert np.all(bank.upper_asymptote == 1.0)
+    assert np.allclose(bank.pseudo_guessing, 0.0)
+    assert np.allclose(bank.upper_asymptote, 1.0)
 
   def test_create_from_1pl_params(self) -> None:
     """Test creating ItemBank from 1PL (difficulty only) parameters."""
@@ -57,16 +57,16 @@ class TestItemBankCreation:
     assert bank.n_items == 3
     assert bank.model == 1  # 1PL (Rasch)
     # a should be 1, c should be 0, d should be 1
-    assert np.all(bank.discrimination == 1.0)
-    assert np.all(bank.pseudo_guessing == 0.0)
-    assert np.all(bank.upper_asymptote == 1.0)
+    assert np.allclose(bank.discrimination, 1.0)
+    assert np.allclose(bank.pseudo_guessing, 0.0)
+    assert np.allclose(bank.upper_asymptote, 1.0)
 
   def test_exposure_rates_initialized_to_zero(self) -> None:
     """Test that exposure rates are initialized to zero."""
     items = np.array([[1.0, 0.0, 0.0, 1.0]])
     bank = ItemBank(items)
 
-    assert np.all(bank.exposure_rates == 0.0)
+    assert np.allclose(bank.exposure_rates, 0.0)
 
   def test_validation_enabled_by_default(self) -> None:
     """Test that validation is enabled by default and catches invalid params."""
@@ -106,7 +106,7 @@ class TestItemBankGenerate:
 
     assert bank.n_items == 30
     assert bank.model == 3
-    assert np.all(bank.upper_asymptote == 1.0)
+    assert np.allclose(bank.upper_asymptote, 1.0)
     assert np.any(bank.pseudo_guessing > 0)
 
   def test_generate_2pl(self) -> None:
@@ -115,8 +115,8 @@ class TestItemBankGenerate:
 
     assert bank.n_items == 20
     assert bank.model == 2
-    assert np.all(bank.pseudo_guessing == 0.0)
-    assert np.all(bank.upper_asymptote == 1.0)
+    assert np.allclose(bank.pseudo_guessing, 0.0)
+    assert np.allclose(bank.upper_asymptote, 1.0)
 
   def test_generate_1pl(self) -> None:
     """Test generating 1PL (Rasch) item bank."""
@@ -124,9 +124,9 @@ class TestItemBankGenerate:
 
     assert bank.n_items == 15
     assert bank.model == 1
-    assert np.all(bank.discrimination == 1.0)
-    assert np.all(bank.pseudo_guessing == 0.0)
-    assert np.all(bank.upper_asymptote == 1.0)
+    assert np.allclose(bank.discrimination, 1.0)
+    assert np.allclose(bank.pseudo_guessing, 0.0)
+    assert np.allclose(bank.upper_asymptote, 1.0)
 
   def test_generate_with_correlation(self) -> None:
     """Test generating items with correlated a and b parameters."""
@@ -192,7 +192,7 @@ class TestItemBankProperties:
     bank = ItemBank(items)
     bank.items[0, 4] = 0.5
 
-    assert bank.exposure_rates[0] == 0.5
+    assert bank.exposure_rates[0] == pytest.approx(0.5)
 
   def test_model_property(self) -> None:
     """Test model property returns correct IRT model."""
@@ -256,8 +256,8 @@ class TestItemBankMethods:
 
     item = bank.get_item(1)
     assert len(item) == 5
-    assert item[0] == 1.5  # discrimination
-    assert item[1] == 1.0  # difficulty
+    assert item[0] == pytest.approx(1.5)  # discrimination
+    assert item[1] == pytest.approx(1.0)  # difficulty
 
   def test_get_item_out_of_bounds_raises(self) -> None:
     """Test that out of bounds index raises IndexError."""
@@ -281,8 +281,8 @@ class TestItemBankMethods:
 
     selected = bank.get_items([0, 2])
     assert selected.shape == (2, 5)
-    assert selected[0, 0] == 1.0
-    assert selected[1, 0] == 0.8
+    assert selected[0, 0] == pytest.approx(1.0)
+    assert selected[1, 0] == pytest.approx(0.8)
 
   def test_update_exposure_rate(self) -> None:
     """Test updating exposure rate for a specific item."""
@@ -290,7 +290,7 @@ class TestItemBankMethods:
     bank = ItemBank(items)
 
     bank.update_exposure_rate(0, 0.75)
-    assert bank.exposure_rates[0] == 0.75
+    assert bank.exposure_rates[0] == pytest.approx(0.75)
 
   def test_update_exposure_rate_invalid_index_raises(self) -> None:
     """Test that invalid index raises IndexError."""
@@ -322,7 +322,7 @@ class TestItemBankMethods:
 
     # Reset
     bank.reset_exposure_rates()
-    assert np.all(bank.exposure_rates == 0.0)
+    assert np.allclose(bank.exposure_rates, 0.0)
 
   def test_icc_scalar_theta(self) -> None:
     """Test computing ICC for a scalar theta."""
@@ -397,11 +397,11 @@ class TestItemBankReset:
 
     # Set some exposure rates
     bank.update_exposure_rate(0, 0.5)
-    assert bank.exposure_rates[0] == 0.5
+    assert bank.exposure_rates[0] == pytest.approx(0.5)
 
     # Reset
     bank.reset_exposure_rates()
-    assert bank.exposure_rates[0] == 0.0
+    assert bank.exposure_rates[0] == pytest.approx(0.0)
 
   def test_reset_clears_exposure_rates(self) -> None:
     """Test that reset() clears all exposure rates."""
@@ -465,7 +465,7 @@ class TestItemBankReset:
       bank.reset()
 
       # Verify reset worked
-      assert np.all(bank.exposure_rates == 0)
+      assert np.allclose(bank.exposure_rates, 0.0)
 
 
 class TestItemBankDunderMethods:
@@ -494,7 +494,7 @@ class TestItemBankDunderMethods:
     bank = ItemBank(items)
 
     item = bank[1]
-    assert item[0] == 1.5
+    assert item[0] == pytest.approx(1.5)
 
   def test_getitem_slice(self) -> None:
     """Test __getitem__ with slice."""
@@ -511,5 +511,5 @@ class TestItemBankDunderMethods:
 
     subset = bank[[0, 2]]
     assert subset.shape == (2, 5)
-    assert subset[0, 0] == 1.0
-    assert subset[1, 0] == 0.8
+    assert subset[0, 0] == pytest.approx(1.0)
+    assert subset[1, 0] == pytest.approx(0.8)

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -29,13 +29,13 @@ class TestMaxInfoSelector:
   def test_init_default(self) -> None:
     """Test default initialization."""
     selector = MaxInfoSelector()
-    assert selector.r_max == 1.0
+    assert selector.r_max == pytest.approx(1.0)
     assert str(selector) == "Maximum Information Selector"
 
   def test_init_with_r_max(self) -> None:
     """Test initialization with r_max."""
     selector = MaxInfoSelector(r_max=0.5)
-    assert selector.r_max == 0.5
+    assert selector.r_max == pytest.approx(0.5)
 
   def test_init_invalid_r_max_raises(self) -> None:
     """Test that invalid r_max raises ValueError."""
@@ -340,7 +340,7 @@ class TestIntervalInfoSelector:
   def test_init_with_interval(self) -> None:
     """Test initialization with interval."""
     selector = IntervalInfoSelector(interval=2.0)
-    assert selector.interval == 2.0
+    assert selector.interval == pytest.approx(2.0)
     assert str(selector) == "Interval Information Selector"
 
   def test_init_default(self) -> None:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -134,15 +134,15 @@ class TestSimulatorProperties:
     """Test that duration is zero before simulation."""
     item_bank = ItemBank.generate_item_bank(50)
     simulator = Simulator(item_bank, examinees=5)
-    assert simulator.duration == 0.0
+    assert simulator.duration == pytest.approx(0.0)
 
   def test_bias_mse_rmse_initially_zero(self) -> None:
     """Test that evaluation metrics are zero initially."""
     item_bank = ItemBank.generate_item_bank(50)
     simulator = Simulator(item_bank, examinees=5)
-    assert simulator.bias == 0.0
-    assert simulator.mse == 0.0
-    assert simulator.rmse == 0.0
+    assert simulator.bias == pytest.approx(0.0)
+    assert simulator.mse == pytest.approx(0.0)
+    assert simulator.rmse == pytest.approx(0.0)
 
   def test_rng_property(self) -> None:
     """Test that rng property returns numpy Generator."""

--- a/tests/test_stopping.py
+++ b/tests/test_stopping.py
@@ -119,14 +119,14 @@ class TestMinErrorStopperInit:
   def test_init_with_min_error(self) -> None:
     """Test initialization with min_error."""
     stopper = MinErrorStopper(0.3)
-    assert stopper.min_error == 0.3
+    assert stopper.min_error == pytest.approx(0.3)
     assert stopper.min_items is None
     assert stopper.max_items is None
 
   def test_init_with_all_params(self) -> None:
     """Test initialization with all parameters."""
     stopper = MinErrorStopper(0.3, min_items=5, max_items=30)
-    assert stopper.min_error == 0.3
+    assert stopper.min_error == pytest.approx(0.3)
     assert stopper.min_items == 5
     assert stopper.max_items == 30
 

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,7 @@ dev = [
     { name = "ipykernel" },
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 docs = [
     { name = "bibtex-pygments-lexer" },
@@ -119,8 +120,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=7.1.0" },
-    { name = "pre-commit", specifier = ">=4.3.0" },
-    { name = "ruff", specifier = ">=0.13.3" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "ruff", specifier = ">=0.15.9" },
+    { name = "ty", specifier = ">=0.0.28" },
 ]
 docs = [
     { name = "bibtex-pygments-lexer", specifier = ">=0.0.1" },
@@ -135,7 +137,7 @@ testing = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "ruff", specifier = ">=0.13.3" },
+    { name = "ruff", specifier = ">=0.15.9" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
 ]
 
@@ -2126,27 +2128,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.5"
+version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/9b/840e0039e65fcf12758adf684d2289024d6140cde9268cc59887dc55189c/ruff-0.15.5.tar.gz", hash = "sha256:7c3601d3b6d76dce18c5c824fc8d06f4eef33d6df0c21ec7799510cde0f159a2", size = 4574214, upload-time = "2026-03-05T20:06:34.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/20/5369c3ce21588c708bcbe517a8fbe1a8dfdb5dfd5137e14790b1da71612c/ruff-0.15.5-py3-none-linux_armv6l.whl", hash = "sha256:4ae44c42281f42e3b06b988e442d344a5b9b72450ff3c892e30d11b29a96a57c", size = 10478185, upload-time = "2026-03-05T20:06:29.093Z" },
-    { url = "https://files.pythonhosted.org/packages/44/ed/e81dd668547da281e5dce710cf0bc60193f8d3d43833e8241d006720e42b/ruff-0.15.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6edd3792d408ebcf61adabc01822da687579a1a023f297618ac27a5b51ef0080", size = 10859201, upload-time = "2026-03-05T20:06:32.632Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/8f/533075f00aaf19b07c5cd6aa6e5d89424b06b3b3f4583bfa9c640a079059/ruff-0.15.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:89f463f7c8205a9f8dea9d658d59eff49db05f88f89cc3047fb1a02d9f344010", size = 10184752, upload-time = "2026-03-05T20:06:40.312Z" },
-    { url = "https://files.pythonhosted.org/packages/66/0e/ba49e2c3fa0395b3152bad634c7432f7edfc509c133b8f4529053ff024fb/ruff-0.15.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba786a8295c6574c1116704cf0b9e6563de3432ac888d8f83685654fe528fd65", size = 10534857, upload-time = "2026-03-05T20:06:19.581Z" },
-    { url = "https://files.pythonhosted.org/packages/59/71/39234440f27a226475a0659561adb0d784b4d247dfe7f43ffc12dd02e288/ruff-0.15.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd4b801e57955fe9f02b31d20375ab3a5c4415f2e5105b79fb94cf2642c91440", size = 10309120, upload-time = "2026-03-05T20:06:00.435Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/87/4140aa86a93df032156982b726f4952aaec4a883bb98cb6ef73c347da253/ruff-0.15.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391f7c73388f3d8c11b794dbbc2959a5b5afe66642c142a6effa90b45f6f5204", size = 11047428, upload-time = "2026-03-05T20:05:51.867Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f7/4953e7e3287676f78fbe85e3a0ca414c5ca81237b7575bdadc00229ac240/ruff-0.15.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8dc18f30302e379fe1e998548b0f5e9f4dff907f52f73ad6da419ea9c19d66c8", size = 11914251, upload-time = "2026-03-05T20:06:22.887Z" },
-    { url = "https://files.pythonhosted.org/packages/77/46/0f7c865c10cf896ccf5a939c3e84e1cfaeed608ff5249584799a74d33835/ruff-0.15.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc6e7f90087e2d27f98dc34ed1b3ab7c8f0d273cc5431415454e22c0bd2a681", size = 11333801, upload-time = "2026-03-05T20:05:57.168Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/01/a10fe54b653061585e655f5286c2662ebddb68831ed3eaebfb0eb08c0a16/ruff-0.15.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1cb7169f53c1ddb06e71a9aebd7e98fc0fea936b39afb36d8e86d36ecc2636a", size = 11206821, upload-time = "2026-03-05T20:06:03.441Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/0d/2132ceaf20c5e8699aa83da2706ecb5c5dcdf78b453f77edca7fb70f8a93/ruff-0.15.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9b037924500a31ee17389b5c8c4d88874cc6ea8e42f12e9c61a3d754ff72f1ca", size = 11133326, upload-time = "2026-03-05T20:06:25.655Z" },
-    { url = "https://files.pythonhosted.org/packages/72/cb/2e5259a7eb2a0f87c08c0fe5bf5825a1e4b90883a52685524596bfc93072/ruff-0.15.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:65bb414e5b4eadd95a8c1e4804f6772bbe8995889f203a01f77ddf2d790929dd", size = 10510820, upload-time = "2026-03-05T20:06:37.79Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/20/b67ce78f9e6c59ffbdb5b4503d0090e749b5f2d31b599b554698a80d861c/ruff-0.15.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d20aa469ae3b57033519c559e9bc9cd9e782842e39be05b50e852c7c981fa01d", size = 10302395, upload-time = "2026-03-05T20:05:54.504Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e5/719f1acccd31b720d477751558ed74e9c88134adcc377e5e886af89d3072/ruff-0.15.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:15388dd28c9161cdb8eda68993533acc870aa4e646a0a277aa166de9ad5a8752", size = 10754069, upload-time = "2026-03-05T20:06:06.422Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/9c/d1db14469e32d98f3ca27079dbd30b7b44dbb5317d06ab36718dee3baf03/ruff-0.15.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b30da330cbd03bed0c21420b6b953158f60c74c54c5f4c1dabbdf3a57bf355d2", size = 11304315, upload-time = "2026-03-05T20:06:10.867Z" },
-    { url = "https://files.pythonhosted.org/packages/28/3a/950367aee7c69027f4f422059227b290ed780366b6aecee5de5039d50fa8/ruff-0.15.5-py3-none-win32.whl", hash = "sha256:732e5ee1f98ba5b3679029989a06ca39a950cced52143a0ea82a2102cb592b74", size = 10551676, upload-time = "2026-03-05T20:06:13.705Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/00/bf077a505b4e649bdd3c47ff8ec967735ce2544c8e4a43aba42ee9bf935d/ruff-0.15.5-py3-none-win_amd64.whl", hash = "sha256:821d41c5fa9e19117616c35eaa3f4b75046ec76c65e7ae20a333e9a8696bc7fe", size = 11678972, upload-time = "2026-03-05T20:06:45.379Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/4e/cd76eca6db6115604b7626668e891c9dd03330384082e33662fb0f113614/ruff-0.15.5-py3-none-win_arm64.whl", hash = "sha256:b498d1c60d2fe5c10c45ec3f698901065772730b411f164ae270bb6bfcc4740b", size = 10965572, upload-time = "2026-03-05T20:06:16.984Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
 ]
 
 [[package]]
@@ -2671,6 +2673,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d5/853561de49fae38c519e905b2d8da9c531219608f1fccc47a0fc2c896980/ty-0.0.29.tar.gz", hash = "sha256:e7936cca2f691eeda631876c92809688dbbab68687c3473f526cd83b6a9228d8", size = 5469221, upload-time = "2026-04-05T15:01:21.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/b7/911f9962115acfa24e3b2ec9d4992dd994c38e8769e1b1d7680bb4d28a51/ty-0.0.29-py3-none-linux_armv6l.whl", hash = "sha256:b8a40955f7660d3eaceb0d964affc81b790c0765e7052921a5f861ff8a471c30", size = 10568206, upload-time = "2026-04-05T15:01:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/fcae2167d4c77a97269f92f11d1b43b03617f81de1283d5d05b43432110c/ty-0.0.29-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6b6849adae15b00bbe2d3c5b078967dcb62eba37d38936b8eeb4c81a82d2e3b8", size = 10442530, upload-time = "2026-04-05T15:01:28.471Z" },
+    { url = "https://files.pythonhosted.org/packages/97/33/5a6bfa240cfcb9c36046ae2459fa9ea23238d20130d8656ff5ac4d6c012a/ty-0.0.29-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dcdd9b17209788152f7b7ea815eda07989152325052fe690013537cc7904ce49", size = 9915735, upload-time = "2026-04-05T15:01:10.365Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/318f45fae232118e81a6306c30f50de42c509c412128d5bd231eab699ffb/ty-0.0.29-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d8ed4789bae78ffaf94462c0d25589a734cab0366b86f2bbcb1bb90e1a7a169", size = 10419748, upload-time = "2026-04-05T15:01:32.375Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a8/5687872e2ab5a0f7dd4fd8456eac31e9381ad4dc74961f6f29965ad4dd91/ty-0.0.29-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91ec374b8565e0ad0900011c24641ebbef2da51adbd4fb69ff3280c8a7eceb02", size = 10394738, upload-time = "2026-04-05T15:01:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/de/68/015d118097eeb95e6a44c4abce4c0a28b7b9dfb3085b7f0ee48e4f099633/ty-0.0.29-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:298a8d5faa2502d3810bbbb47a030b9455495b9921594206043c785dd61548cf", size = 10910613, upload-time = "2026-04-05T15:01:17.17Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/47ce3c6c53e0670eadbe80756b167bf80ed6681d1ba57cfde2e8065a13d1/ty-0.0.29-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c8fba1a3524c6109d1e020d92301c79d41bf442fa8d335b9fa366239339cb70", size = 11475750, upload-time = "2026-04-05T15:01:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cf/e361845b1081c9264ad5b7c963231bab03f2666865a9f2a115c4233f2137/ty-0.0.29-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c48adf88a70d264128c39ee922ed14a947817fced1e93c08c1a89c9244edcde", size = 11190055, upload-time = "2026-04-05T15:01:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/79/12/0fb0857e9a62cb11586e9a712103877bbf717f5fb570d16634408cfdefee/ty-0.0.29-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce0a7a0e96bc7b42518cd3a1a6a6298ef64ff40ca4614355c1aa807059b5c6f", size = 11020539, upload-time = "2026-04-05T15:01:37.022Z" },
+    { url = "https://files.pythonhosted.org/packages/20/36/5a26753802083f80cd125db6c4348ad42b3c982ec36e718e0bf4c18f75e5/ty-0.0.29-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6ac86a05b4a3731d45365ab97780acc7b8146fa62fccb3cbe94fe6546c67a97", size = 10396399, upload-time = "2026-04-05T15:01:26.167Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e6/b4e75b5752239ab3ab400f19faef4dbef81d05aab5d3419fda0c062a3765/ty-0.0.29-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6bbbf53141af0f3150bf288d716263f1a3550054e4b3551ca866d38192ba9891", size = 10421461, upload-time = "2026-04-05T15:01:08.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/21/1084b5b609f9abed62070ec0b31c283a403832a6310c8bbc208bd45ee1e6/ty-0.0.29-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1c9e06b770c1d0ff5efc51e34312390db31d53fcf3088163f413030b42b74f84", size = 10599187, upload-time = "2026-04-05T15:01:23.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a1/ce19a2ca717bbcc1ee11378aba52ef70b6ce5b87245162a729d9fdc2360f/ty-0.0.29-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0307fe37e3f000ef1a4ae230bbaf511508a78d24a5e51b40902a21b09d5e6037", size = 11121198, upload-time = "2026-04-05T15:01:15.22Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6b/f1430b279af704321566ce7ec2725d3d8258c2f815ebd93e474c64cd4543/ty-0.0.29-py3-none-win32.whl", hash = "sha256:7a2a898217960a825f8bc0087e1fdbaf379606175e98f9807187221d53a4a8ed", size = 9995331, upload-time = "2026-04-05T15:01:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ef/3ef01c17785ff9a69378465c7d0faccd48a07b163554db0995e5d65a5a23/ty-0.0.29-py3-none-win_amd64.whl", hash = "sha256:fc1294200226b91615acbf34e0a9ad81caf98c081e9c6a912a31b0a7b603bc3f", size = 11023644, upload-time = "2026-04-05T15:01:04.432Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/55/87280a994d6a2d2647c65e12abbc997ed49835794366153c04c4d9304d76/ty-0.0.29-py3-none-win_arm64.whl", hash = "sha256:f9794bbd1bb3ce13f78c191d0c89ae4c63f52c12b6daa0c6fe220b90d019d12c", size = 10428165, upload-time = "2026-04-05T15:01:34.665Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- align Ruff versions, enable BLE and scoped S rules, and clean the repo under the current Ruff config
- add ty as a dev dependency scoped to src/catsim with a narrow rule set and fix the initial division-by-zero issue
- modernize the pre-commit job and core GitHub Actions versions while keeping artifact actions on the current major

## Validation
- uv run ruff check .
- uv run pre-commit run --all-files
- uv run ty check